### PR TITLE
Backports CHEF-3164. Resolves issue #1

### DIFF
--- a/libraries/chef_gem.rb
+++ b/libraries/chef_gem.rb
@@ -32,6 +32,7 @@ if(Gem::Version.new(Chef::VERSION) < Gem::Version.new('0.10.12'))
     end
 
     def after_created
+      Gem.clear_paths # NOTE: Related to CHEF-3164
       Array(@action).flatten.compact.each do |action|
         self.run_action(action)
       end


### PR DESCRIPTION
In versions of Chef >= 10.14.0 this fix is provided via the
cleanup_after_converge callback within the Rubygems package
provider. Since this callback does not exist in previous
versions, the resource is patched.
